### PR TITLE
fix: scrolloff not activating after mouse event

### DIFF
--- a/src/ScrollOffsetCM6.ts
+++ b/src/ScrollOffsetCM6.ts
@@ -3,7 +3,7 @@ import { Prec } from '@codemirror/state'
 
 const eventHandlers = {
   mousedown(event: MouseEvent, view: EditorView) {
-    this.switch = false;
+    this.switch = true;
   },
   keydown(event: KeyboardEvent, view: EditorView) {
     this.switch = true;


### PR DESCRIPTION
There is a bug that the scroll offset is effectively disabled after using the mouse. For me, the offset is only re-activated after unfocussing Obsidian and focussing back (alt+tab, alt+tab, effectively).

This PR is more of a band aid than an actual solution, since I am not familiar enough with the code for a proper solution. However, it does appear to work..